### PR TITLE
fixed some layout issues

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -4,7 +4,7 @@ import { BlueLine } from "./Shape";
 export function Layout({ children, className }) {
   return (
     <div className="overflow-hidden relative">
-      <div className="h-screen bg-background font-heiti py-4 flex flex-col overflow-scroll">
+      <div className="h-screen bg-background font-heiti py-4 flex flex-col overflow-auto">
         <div className="space-y-2 w-full">
           <BlueLine className="border-b-4" />
           <BlueLine className="border-b-8" />

--- a/src/hooks/useSwipe.jsx
+++ b/src/hooks/useSwipe.jsx
@@ -5,6 +5,7 @@ function unify(e) {
 }
 
 export function useSwipe() {
+  // there is a bug here, its does not stop swiping on the last item
   const [direction, setDirection] = useState(0);
   const [originX, setOriginX] = useState(0);
 

--- a/src/pages/Order/Products.jsx
+++ b/src/pages/Order/Products.jsx
@@ -9,7 +9,7 @@ import { useOrderDispatch } from "../../contexts/orders";
 
 function Title({ name, price }) {
   return (
-    <div className="py-2 max-w-xxs">
+    <div className="p-2">
       <h1 className="text-5xl text-primary">{name}</h1>
       <h2 className="text-2xl text-on-primary">${price}</h2>
     </div>
@@ -29,7 +29,7 @@ function Product({ className, style, name, img, isFocus, onClick }) {
       }}
       onClick={onClick}
     >
-      <img src={img} alt={name} draggable={false} />
+      <img src={img} alt={name} draggable={false} className="mx-auto" />
     </div>
   );
 }

--- a/src/pages/Order/Tabs.jsx
+++ b/src/pages/Order/Tabs.jsx
@@ -19,7 +19,7 @@ export default function Tabs({ products }) {
   const isActive = equals(product);
 
   return (
-    <nav className="space-x-2 flex flex-nowrap items-end overflow-scroll">
+    <nav className="space-x-2 flex flex-nowrap items-end overflow-auto">
       {types.map((item) => (
         <Link
           key={item}


### PR DESCRIPTION
- use `overflow-auto` instead of `overflow-scroll` to prevent scroll if not necessary 
- fixed title width because it should not be fixed, otherwise there will be 2 line 
- there is a bug in swipe drinks carousel, it does not stop on the last item, so it should respect the min-max or reset to first one if swipe the last item 